### PR TITLE
Update 'windows-2019' to 'windows-2025' in rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
           rust: stable
           target: x86_64-apple-darwin
         - build: win-msvc
-          os: windows-2019
+          os: windows-2025
           rust: stable
           target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
For further details see https://github.com/actions/runner-images/issues/12045