### PR TITLE
Feat/iced-task-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 regex = "1"
-iced = "0.13.1"
+iced = { version = "0.13.1", features = ["tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 regex = "1"
 iced = { version = "0.13.1", features = ["tokio"] }
+thiserror = "2.0.12"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod proxy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
+use std::process::Command;
 
 use iced::widget::{button, center, column, radio, slider, text};
-use iced::{Center, Element, Fill};
+use iced::{Center, Element, Fill, Task};
 use rfd::FileDialog;
 
 mod proxy;
@@ -23,16 +24,35 @@ enum Message {
     PaddingChanged(f64),
     FileSelectButtonPressed,
     StartButtonPressed,
+    ProxyPdfFileCreated(Option<PathBuf>),
+}
+
+fn open_file(path: PathBuf) {
+    #[cfg(target_os = "windows")]
+    let mut cmd = Command::new("explorer");
+
+    #[cfg(target_os = "macos")]
+    let mut cmd = Command::new("open");
+
+    #[cfg(target_os = "linux")]
+    let mut cmd = Command::new("xdg-open");
+
+    cmd.arg(path);
+
+    // This will block, but if you don't mind, it's fine for quick tasks
+    cmd.spawn().unwrap();
 }
 
 impl ProxyConfig {
-    fn update(&mut self, message: Message) {
+    fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::SchemaChange(schema) => {
                 self.selected_schema = schema;
+                Task::none()
             }
             Message::PaddingChanged(padding) => {
                 self.padding_value = padding;
+                Task::none()
             }
             Message::FileSelectButtonPressed => {
                 // Block until user selects file
@@ -42,13 +62,23 @@ impl ProxyConfig {
                     .pick_file();
 
                 self.file_path = selected_file_path;
+                Task::none()
             }
-            Message::StartButtonPressed => {
+            Message::StartButtonPressed => Task::perform(
                 proxy::run(
                     self.file_path.clone(),
                     self.selected_schema,
                     self.padding_value,
-                );
+                ),
+                Message::ProxyPdfFileCreated,
+            ),
+            Message::ProxyPdfFileCreated(pdf_path_opt) => {
+                if let Some(pdf_path_opt) = pdf_path_opt {
+                    open_file(pdf_path_opt);
+                } else {
+                    eprintln!("PDF creation failed, no file path.");
+                }
+                Task::none()
             }
         }
     }
@@ -122,8 +152,8 @@ fn change_config_properly() {
         file_path: None,
     };
 
-    config.update(Message::SchemaChange(true));
-    config.update(Message::PaddingChanged(70.0));
+    let _ = config.update(Message::SchemaChange(true));
+    let _ = config.update(Message::PaddingChanged(70.0));
 
     assert_eq!(config.selected_schema, true);
     assert_eq!(config.padding_value, 70.0)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ enum Message {
     PaddingChanged(f64),
     FileSelectButtonPressed,
     StartButtonPressed,
-    ProxyPdfFileCreated(Option<PathBuf>),
+    ProxyPdfFileCreated(Result<PathBuf, proxy::PdfPathNotCreated>),
 }
 
 fn open_file(path: PathBuf) {
@@ -65,16 +65,17 @@ impl ProxyConfig {
                 Task::none()
             }
             Message::StartButtonPressed => Task::perform(
-                proxy::run(
+                proxy::main(
                     self.file_path.clone(),
                     self.selected_schema,
                     self.padding_value,
                 ),
                 Message::ProxyPdfFileCreated,
             ),
-            Message::ProxyPdfFileCreated(pdf_path_opt) => {
-                if let Some(pdf_path_opt) = pdf_path_opt {
-                    open_file(pdf_path_opt);
+
+            Message::ProxyPdfFileCreated(pdf_path_res) => {
+                if let Ok(pdf_path_res) = pdf_path_res {
+                    open_file(pdf_path_res);
                 } else {
                     eprintln!("PDF creation failed, no file path.");
                 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -88,11 +88,11 @@ async fn run(file_path: Option<PathBuf>, grid: bool, padding_length: f64) -> Res
         match get_card_image_url(&client, &card_name, set_name.as_deref(), "png").await {
             Ok(card_image) => {
                 if grid {
-                    let image_future = get_card_image(card_image.front);
+                    let image_future = get_card_image(client.clone(), card_image.front);
                     image_futures.push(image_future);
                 } else {
                     for image_url in card_image {
-                        let image_future = get_card_image(image_url);
+                        let image_future = get_card_image(client.clone(), image_url);
                         image_futures.push(image_future);
                     }
                 }
@@ -332,11 +332,13 @@ async fn get_card_image_url(
     }
 }
 
-async fn get_card_image(png_url: Option<String>) -> Result<Image> {
+async fn get_card_image(client: Client, png_url: Option<String>) -> Result<Image> {
     if let Some(url) = png_url {
         println!("[Download] Downloading image from URL: {}", url);
         // downloading image from url to bytes
-        let response = reqwest::get(url)
+        let response = client
+            .get(url)
+            .send()
             .await
             .context("Failed to fetch image from URL")?;
         let img_bytes = response

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,4 @@
-use mtg_proxy_creator_rust::proxy::run;
+use mtg_proxy_creator_rust::proxy::main;
 use std::fs;
 use std::{path::PathBuf, str::FromStr};
 
@@ -6,9 +6,9 @@ const TEST_TXT_FILE_PATH: &str = "input/test.txt";
 
 #[tokio::test]
 async fn test_run_function() {
-    let path = run(PathBuf::from_str(TEST_TXT_FILE_PATH).ok(), false, 0.0)
+    let path = main(PathBuf::from_str(TEST_TXT_FILE_PATH).ok(), false, 0.0)
         .await
-        .expect("run() failed");
+        .expect("main() failed");
 
     assert!(path.exists(), "PDF file does not exist");
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,18 @@
+use mtg_proxy_creator_rust::proxy::run;
+use std::fs;
+use std::{path::PathBuf, str::FromStr};
+
+const TEST_TXT_FILE_PATH: &str = "input/test.txt";
+
+#[tokio::test]
+async fn test_run_function() {
+    let path = run(PathBuf::from_str(TEST_TXT_FILE_PATH).ok(), false, 0.0)
+        .await
+        .expect("run() failed");
+
+    assert!(path.exists(), "PDF file does not exist");
+
+    let metadata = fs::metadata(path).expect("Failed to get metadata");
+    let size = metadata.len();
+    assert!(size > 0, "PDF file is empty");
+}


### PR DESCRIPTION
- **Cargo.toml**: Add thiserror; switch iced to { version = "0.13.1", features = ["tokio"] }
- **src/lib.rs**: New file added
- **src/main.rs**: Updated to integrate async/iced Task flow
    - Refactor *open_file* function to open PDF depending on the OS
- **src/proxy.rs**: Large refactor; async image fetch and revised error handling
    - Async requests for downloading card images
    - Main function returns path to the created PDF or error information
- **tests/integration_test.rs**: New integration test added